### PR TITLE
Added TdlgStyledEdit which adds syntax highlighting

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -102,30 +102,33 @@ if(wxWidgetsSource_ADDED)
 
 
   set(WX_LIBRARIES
-      ${wxWidgets_INSTALL_DIR}/lib/libwx_gtk3u_gl-${wxVERSION_FAMILY}.a
-      ${wxWidgets_INSTALL_DIR}/lib/libwx_gtk3u_core-${wxVERSION_FAMILY}.a
-      ${wxWidgets_INSTALL_DIR}/lib/libwx_gtk3u_aui-${wxVERSION_FAMILY}.a
-      ${wxWidgets_INSTALL_DIR}/lib/libwx_gtk3u_adv-${wxVERSION_FAMILY}.a
-      ${wxWidgets_INSTALL_DIR}/lib/libwx_gtk3u_html-${wxVERSION_FAMILY}.a
-      ${wxWidgets_INSTALL_DIR}/lib/libwx_gtk3u_propgrid-${wxVERSION_FAMILY}.a
-      ${wxWidgets_INSTALL_DIR}/lib/libwx_gtk3u_qa-${wxVERSION_FAMILY}.a
-      ${wxWidgets_INSTALL_DIR}/lib/libwx_gtk3u_ribbon-${wxVERSION_FAMILY}.a
-      ${wxWidgets_INSTALL_DIR}/lib/libwx_gtk3u_richtext-${wxVERSION_FAMILY}.a
+      # Order matters - more specific libraries first, then base libraries
       ${wxWidgets_INSTALL_DIR}/lib/libwx_gtk3u_stc-${wxVERSION_FAMILY}.a
       ${wxWidgets_INSTALL_DIR}/lib/libwx_gtk3u_xrc-${wxVERSION_FAMILY}.a
+      ${wxWidgets_INSTALL_DIR}/lib/libwx_gtk3u_html-${wxVERSION_FAMILY}.a
+      ${wxWidgets_INSTALL_DIR}/lib/libwx_gtk3u_qa-${wxVERSION_FAMILY}.a
+      ${wxWidgets_INSTALL_DIR}/lib/libwx_gtk3u_adv-${wxVERSION_FAMILY}.a
+      ${wxWidgets_INSTALL_DIR}/lib/libwx_gtk3u_core-${wxVERSION_FAMILY}.a
+      ${wxWidgets_INSTALL_DIR}/lib/libwx_baseu-${wxVERSION_FAMILY}.a
+      ${wxWidgets_INSTALL_DIR}/lib/libwx_baseu_xml-${wxVERSION_FAMILY}.a
+      ${wxWidgets_INSTALL_DIR}/lib/libwx_baseu_net-${wxVERSION_FAMILY}.a
 
-      ${wxWidgets_INSTALL_DIR}/lib/libwxregexu-${wxVERSION_FAMILY}.a
+      # Additional component libraries
+      ${wxWidgets_INSTALL_DIR}/lib/libwx_gtk3u_gl-${wxVERSION_FAMILY}.a
+      ${wxWidgets_INSTALL_DIR}/lib/libwx_gtk3u_aui-${wxVERSION_FAMILY}.a
+      ${wxWidgets_INSTALL_DIR}/lib/libwx_gtk3u_propgrid-${wxVERSION_FAMILY}.a
+      ${wxWidgets_INSTALL_DIR}/lib/libwx_gtk3u_ribbon-${wxVERSION_FAMILY}.a
+      ${wxWidgets_INSTALL_DIR}/lib/libwx_gtk3u_richtext-${wxVERSION_FAMILY}.a
+
+      # Support libraries
       ${wxWidgets_INSTALL_DIR}/lib/libwxscintilla-${wxVERSION_FAMILY}.a
+      ${wxWidgets_INSTALL_DIR}/lib/libwxregexu-${wxVERSION_FAMILY}.a
 
+      # Image libraries
       ${wxWidgets_INSTALL_DIR}/lib/libwxjpeg-${wxVERSION_FAMILY}.a
       ${wxWidgets_INSTALL_DIR}/lib/libwxpng-${wxVERSION_FAMILY}.a
       ${wxWidgets_INSTALL_DIR}/lib/libwxtiff-${wxVERSION_FAMILY}.a
       ${wxWidgets_INSTALL_DIR}/lib/libwxzlib-${wxVERSION_FAMILY}.a
-
-      ${wxWidgets_INSTALL_DIR}/lib/libwx_baseu_net-${wxVERSION_FAMILY}.a
-      ${wxWidgets_INSTALL_DIR}/lib/libwx_baseu_xml-${wxVERSION_FAMILY}.a
-      ${wxWidgets_INSTALL_DIR}/lib/libwx_baseu-${wxVERSION_FAMILY}.a
-
   )
   set(WX_LIBRARIES ${WX_LIBRARIES} PARENT_SCOPE)
   set(WX_SYSTEM_LIBS

--- a/olex/ctrls.h
+++ b/olex/ctrls.h
@@ -11,6 +11,7 @@
 #define __olx_ctrl_H
 #include "actions.h"
 #include "ctrls/olxctrlbase.h"
+#include "wx/stc/stc.h"
 #include "wx/wx.h"
 
 class olxCommandEvent;

--- a/olex/edit.cpp
+++ b/olex/edit.cpp
@@ -59,3 +59,54 @@ void TdlgEdit::SetText(const olxstr& text)  {
 //..............................................................................
 olxstr TdlgEdit::GetText()  {  return Text->GetValue();  }
 //..............................................................................
+
+// Styled edit dialog
+// edit text dialog dialog
+TdlgStyledEdit::TdlgStyledEdit(TMainFrame *ParentFrame, bool MultiLine):
+  //TDialog(ParentFrame, -1, wxT("Edit"), wxT("dlgEdit"))
+  wxDialog(ParentFrame, -1,  wxT("Edit"), wxPoint(0, 0), wxDefaultSize, wxMAXIMIZE_BOX | wxRESIZE_BORDER | wxDEFAULT_DIALOG_STYLE, wxT("dlgEdit")), WI(this)
+{
+  int fontSize = 12, charNumber = 75;
+  FParent = ParentFrame;
+
+  int flags = 0;
+  int height = 25, width = fontSize*charNumber;
+  if( MultiLine )  {
+    flags = wxTE_MULTILINE|wxTE_DONTWRAP;
+    height = 350;
+  }
+  Text = new wxStyledTextCtrl(this, -1, wxDefaultPosition, wxSize(width, height));
+  //Text->SetSize(width, height);
+  wxFont fnt(fontSize, wxMODERN, wxNORMAL, wxNORMAL);
+  Text->SetFont(fnt);
+
+  wxBoxSizer *GlobalSizer = new wxBoxSizer(wxVERTICAL );
+  GlobalSizer->Add(Text, 1, wxEXPAND | wxALL, 3);
+
+  wxBoxSizer *ButtonsSizer = new wxBoxSizer( wxHORIZONTAL );
+  ButtonsSizer->Add( new wxButton( this, wxID_OK, wxT("OK") ), 0, wxALL, 3);
+  ButtonsSizer->Add( new wxButton( this, wxID_CANCEL, wxT("Cancel") ), 0, wxALL, 3);
+  //ButtonsSizer->SetDimension(0, height+1, width, 30);
+  //this->WI.SetWidth(width+5);
+  //this->WI.SetHeight(height+70);
+  GlobalSizer->Add(ButtonsSizer,0, wxALL, 3);
+
+
+  SetSizer(GlobalSizer);
+  GlobalSizer->SetSizeHints(this);
+
+  //delete ButtonsSizer;
+  Center();
+  FParent->RestorePosition(this);
+}
+//..............................................................................
+TdlgStyledEdit::~TdlgStyledEdit()  {
+  FParent->SavePosition(this);
+}
+//..............................................................................
+void TdlgStyledEdit::SetText(const olxstr& text)  {
+  Text->SetValue(text.u_str());
+}
+//..............................................................................
+olxstr TdlgStyledEdit::GetText()  {  return Text->GetValue();  }
+//..............................................................................

--- a/olex/edit.cpp
+++ b/olex/edit.cpp
@@ -108,5 +108,34 @@ void TdlgStyledEdit::SetText(const olxstr& text)  {
   Text->SetValue(text.u_str());
 }
 //..............................................................................
+void TdlgStyledEdit::SetLexer(int style)
+{
+  Text->SetLexer(style);
+  if (style == wxSTC_LEX_PYTHON)
+  {
+    Text->SetKeyWords(0, wxT("and as assert break class continue def del elif else except exec finally for from global if import in is lambda not or pass print raise return try while with yield"));
+    // Comments
+    Text->StyleSetSpec(wxSTC_P_COMMENTLINE, "fore:#007F00");
+    Text->StyleSetSpec(wxSTC_P_COMMENTBLOCK, "fore:#007F00");
+    // Numbers
+    Text->StyleSetSpec(wxSTC_P_NUMBER, "fore:#007F7F");
+    // Strings
+    Text->StyleSetSpec(wxSTC_P_STRING, "fore:#7F007F");
+    Text->StyleSetSpec(wxSTC_P_CHARACTER, "fore:#7F007F");
+    // Keywords
+    Text->StyleSetSpec(wxSTC_P_WORD, "fore:#00007F,bold");
+    // Triple quotes
+    Text->StyleSetSpec(wxSTC_P_TRIPLE, "fore:#7F0000");
+    Text->StyleSetSpec(wxSTC_P_TRIPLEDOUBLE, "fore:#7F0000");
+    // Class and function definitions
+    Text->StyleSetSpec(wxSTC_P_CLASSNAME, "fore:#0000FF,bold");
+    Text->StyleSetSpec(wxSTC_P_DEFNAME, "fore:#007F7F,bold");
+    // Operators
+    Text->StyleSetSpec(wxSTC_P_OPERATOR, "bold");
+    Text->StyleSetSpec(wxSTC_P_STRINGEOL, "fore:#000000,back:#E0C0E0,eolfilled");
+  }
+
+}
+//..............................................................................
 olxstr TdlgStyledEdit::GetText()  {  return Text->GetValue();  }
 //..............................................................................

--- a/olex/edit.cpp
+++ b/olex/edit.cpp
@@ -59,24 +59,18 @@ void TdlgEdit::SetText(const olxstr& text)  {
 //..............................................................................
 olxstr TdlgEdit::GetText()  {  return Text->GetValue();  }
 //..............................................................................
-
 // Styled edit dialog
-// edit text dialog dialog
 TdlgStyledEdit::TdlgStyledEdit(TMainFrame *ParentFrame, bool MultiLine):
-  //TDialog(ParentFrame, -1, wxT("Edit"), wxT("dlgEdit"))
   wxDialog(ParentFrame, -1,  wxT("Edit"), wxPoint(0, 0), wxDefaultSize, wxMAXIMIZE_BOX | wxRESIZE_BORDER | wxDEFAULT_DIALOG_STYLE, wxT("dlgEdit")), WI(this)
 {
   int fontSize = 12, charNumber = 75;
   FParent = ParentFrame;
 
-  int flags = 0;
   int height = 25, width = fontSize*charNumber;
   if( MultiLine )  {
-    flags = wxTE_MULTILINE|wxTE_DONTWRAP;
     height = 350;
   }
   Text = new wxStyledTextCtrl(this, -1, wxDefaultPosition, wxSize(width, height));
-  //Text->SetSize(width, height);
   wxFont fnt(fontSize, wxMODERN, wxNORMAL, wxNORMAL);
   Text->SetFont(fnt);
 
@@ -86,16 +80,12 @@ TdlgStyledEdit::TdlgStyledEdit(TMainFrame *ParentFrame, bool MultiLine):
   wxBoxSizer *ButtonsSizer = new wxBoxSizer( wxHORIZONTAL );
   ButtonsSizer->Add( new wxButton( this, wxID_OK, wxT("OK") ), 0, wxALL, 3);
   ButtonsSizer->Add( new wxButton( this, wxID_CANCEL, wxT("Cancel") ), 0, wxALL, 3);
-  //ButtonsSizer->SetDimension(0, height+1, width, 30);
-  //this->WI.SetWidth(width+5);
-  //this->WI.SetHeight(height+70);
   GlobalSizer->Add(ButtonsSizer,0, wxALL, 3);
 
 
   SetSizer(GlobalSizer);
   GlobalSizer->SetSizeHints(this);
 
-  //delete ButtonsSizer;
   Center();
   FParent->RestorePosition(this);
 }

--- a/olex/edit.h
+++ b/olex/edit.h
@@ -22,4 +22,16 @@ public:
   olxstr GetText();
   TWindowInterface WI;
 };
+
+class TdlgStyledEdit: public wxDialog  {
+private:
+  wxStyledTextCtrl *Text;
+  TMainFrame *FParent;
+public:
+  TdlgStyledEdit(TMainFrame *ParentFrame, bool MultiLine);
+  ~TdlgStyledEdit();
+  void SetText(const olxstr& Text);
+  olxstr GetText();
+  TWindowInterface WI;
+};
 #endif

--- a/olex/edit.h
+++ b/olex/edit.h
@@ -31,6 +31,7 @@ public:
   TdlgStyledEdit(TMainFrame *ParentFrame, bool MultiLine);
   ~TdlgStyledEdit();
   void SetText(const olxstr& Text);
+  void SetLexer(int style);
   olxstr GetText();
   TWindowInterface WI;
 };

--- a/olex/xpprocs.cpp
+++ b/olex/xpprocs.cpp
@@ -3414,8 +3414,9 @@ void TMainForm::macPopup(TStrObjList& Cmds, const TParamList& Options, TMacroDat
 //..............................................................................
 void TMainForm::macPython(TStrObjList &Cmds, const TParamList &Options, TMacroData &E)  {
   if( Options.Contains('i') || Options.Contains('l') )  {
-    TdlgEdit *dlg = new TdlgEdit(this, true);
+    auto *dlg = new TdlgStyledEdit(this, true);
     dlg->SetTitle( wxT("Python script editor") );
+    dlg->SetLexer(wxSTC_LEX_PYTHON);
     if( Options.Contains('l') )  {
       olxstr FN = PickFile("Open File",
         olxstr("Python scripts (*.py)|*.py")  <<


### PR DESCRIPTION
This also replaces the base TdlgEdit on python in @py -i. I also had to change around the order of the includes in the CMakeLists.txt.
This was done for editing OCC input files and I tried with Python because this doesn't natively support toml. But I wanted to test if it worked as I imagined. 
Is this good? I figured putting this class into the edit.h and edit.cpp was fine as it was mostly based on those classes, but it implements the wxStyledTextCtrl class.